### PR TITLE
HLL squash patch

### DIFF
--- a/src/java/com/github/prasanthj/hll/HLLDenseRegister.java
+++ b/src/java/com/github/prasanthj/hll/HLLDenseRegister.java
@@ -63,10 +63,22 @@ public class HLLDenseRegister implements HLLRegister {
   // this is a lossy invert of the function above, which produces a hashcode
   // which collides with the current winner of the register (we lose all higher 
   // bits, but we get all bits useful for lesser p-bit options)
+
+  // +-------------|-------------+
+  // |xxxx100000000|1000000000000|  (lr=9 + idx=1024)
+  // +-------------|-------------+
+  //                \
+  // +---------------|-----------+
+  // |xxxx10000000010|00000000000|  (lr=2 + idx=0)
+  // +---------------|-----------+
+
+  // This shows the relevant bits of the original hash value
+  // and how the conversion is moving bits from the index value
+  // over to the leading zero computation
+
   public void extractLowBitsTo(HLLRegister dest) {
-    for (int i = 0; i < register.length; i++) {
-      int idx = i;
-      byte lr = register[i]; // this can be a max of 65, never > 127
+    for (int idx = 0; idx < register.length; idx++) {
+      byte lr = register[idx]; // this can be a max of 65, never > 127
       if (lr != 0) {
         dest.add((long) ((1 << (p + lr - 1)) | idx));
       }

--- a/src/java/com/github/prasanthj/hll/HLLDenseRegister.java
+++ b/src/java/com/github/prasanthj/hll/HLLDenseRegister.java
@@ -60,6 +60,19 @@ public class HLLDenseRegister implements HLLRegister {
     return set(registerIdx, (byte) lr);
   }
 
+  // this is a lossy invert of the function above, which produces a hashcode
+  // which collides with the current winner of the register (we lose all higher 
+  // bits, but we get all bits useful for lesser p-bit options)
+  public void extractLowBitsTo(HLLRegister dest) {
+    for (int i = 0; i < register.length; i++) {
+      int idx = i;
+      byte lr = register[i]; // this can be a max of 65, never > 127
+      if (lr != 0) {
+        dest.add((long) ((1 << (p + lr - 1)) | idx));
+      }
+    }
+  }
+
   public boolean set(int idx, byte value) {
     boolean updated = false;
     if (idx < register.length && value > register[idx]) {

--- a/src/java/com/github/prasanthj/hll/HLLSparseRegister.java
+++ b/src/java/com/github/prasanthj/hll/HLLSparseRegister.java
@@ -209,7 +209,7 @@ public class HLLSparseRegister implements HLLRegister {
     for (Entry<Integer, Byte> entry : sparseMap.entrySet()) {
       int idx = entry.getKey();
       byte lr = entry.getValue(); // this can be a max of 65, never > 127
-      if (lr > 0) {
+      if (lr != 0) {
         // should be a no-op for sparse
         dest.add((long) ((1 << (p + lr - 1)) | idx));
       }

--- a/src/java/com/github/prasanthj/hll/HLLSparseRegister.java
+++ b/src/java/com/github/prasanthj/hll/HLLSparseRegister.java
@@ -16,10 +16,11 @@
 
 package com.github.prasanthj.hll;
 
-import java.util.Map;
-
 import it.unimi.dsi.fastutil.ints.Int2ByteAVLTreeMap;
 import it.unimi.dsi.fastutil.ints.Int2ByteSortedMap;
+
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class HLLSparseRegister implements HLLRegister {
 
@@ -201,6 +202,18 @@ public class HLLSparseRegister implements HLLRegister {
       mergeTempListToSparseMap();
     }
     return sparseMap;
+  }
+
+  // this is effectively the same as the dense register impl.
+  public void extractLowBitsTo(HLLRegister dest) {
+    for (Entry<Integer, Byte> entry : sparseMap.entrySet()) {
+      int idx = entry.getKey();
+      byte lr = entry.getValue(); // this can be a max of 65, never > 127
+      if (lr > 0) {
+        // should be a no-op for sparse
+        dest.add((long) ((1 << (p + lr - 1)) | idx));
+      }
+    }
   }
 
   public int getP() {

--- a/src/java/com/github/prasanthj/hll/HyperLogLog.java
+++ b/src/java/com/github/prasanthj/hll/HyperLogLog.java
@@ -491,7 +491,7 @@ public class HyperLogLog {
     final HLLDenseRegister result = hll.denseRegister;
 
     if (encoding == EncodingType.SPARSE) {
-      sparseRegister.extractLowBitsTo(result);;
+      sparseRegister.extractLowBitsTo(result);
     } else if (encoding == EncodingType.DENSE) {
       denseRegister.extractLowBitsTo(result);
     }

--- a/src/test/com/github/prasanthj/hll/TestHyperLogLog.java
+++ b/src/test/com/github/prasanthj/hll/TestHyperLogLog.java
@@ -266,4 +266,31 @@ public class TestHyperLogLog {
     double delta = threshold * size / 100;
     assertEquals((double) size, (double) hll.count(), delta);
   }
+
+  @Test
+  public void testHLLSquash() {
+    final int size = 1000;
+
+    HyperLogLog hlls[] = new HyperLogLog[16];
+    for (int k = 8; k < hlls.length; k++) {
+      final HyperLogLog hll = HyperLogLog.builder()
+          .setEncoding(EncodingType.DENSE).setNumRegisterIndexBits(k).build();
+      for (int i = 0; i < size; i++) {
+        hll.addLong(i);
+      }
+      hlls[k] = hll;
+    }
+
+    for (int k = 8; k < hlls.length; k++) {
+      for (int j = k + 1; j < hlls.length; j++) {
+        final HyperLogLog large = hlls[j];
+        final HyperLogLog small = hlls[k];
+        final HyperLogLog mush = large.squash(small.getNumRegisterIndexBits());
+        assertEquals(small.count(), mush.count(), 0);
+        double threshold = size > 40000 ? longRangeTolerance : shortRangeTolerance;
+        double delta = threshold * size / 100;
+        assertEquals((double) size, (double) mush.count(), delta);
+      }
+    }
+  }
 }

--- a/src/test/com/github/prasanthj/hll/TestHyperLogLog.java
+++ b/src/test/com/github/prasanthj/hll/TestHyperLogLog.java
@@ -33,14 +33,18 @@ public class TestHyperLogLog {
     HyperLogLog hll3 = HyperLogLog.builder().setEncoding(EncodingType.DENSE).build();
     HyperLogLog hll4 = HyperLogLog.builder().setNumRegisterIndexBits(16)
         .setEncoding(EncodingType.DENSE).build();
+    HyperLogLog hll5 = HyperLogLog.builder().setNumRegisterIndexBits(12)
+        .setEncoding(EncodingType.DENSE).build();
     int size = 1000;
     for (int i = 0; i < size; i++) {
       hll.addLong(i);
       hll2.addLong(size + i);
       hll3.addLong(2 * size + i);
+      hll4.addLong(3 * size + i);
     }
     double threshold = size > 40000 ? longRangeTolerance : shortRangeTolerance;
     double delta = threshold * size / 100;
+    double delta4 = threshold * (4*size) / 100;
     assertEquals((double) size, (double) hll.count(), delta);
     assertEquals((double) size, (double) hll2.count(), delta);
 
@@ -59,8 +63,13 @@ public class TestHyperLogLog {
     assertEquals((double) 3 * size, (double) hll.count(), delta);
     assertEquals(EncodingType.DENSE, hll.getEncoding());
 
-    // invalid merge -- register set size doesn't match
+    // valid merge -- register set size gets bigger (also 4k items 
     hll.merge(hll4);
+    assertEquals((double) 4 * size, (double) hll.count(), delta4);
+    assertEquals(EncodingType.DENSE, hll.getEncoding());
+    
+    // invalid merge -- smaller register merge to bigger
+    hll.merge(hll5);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -70,14 +79,18 @@ public class TestHyperLogLog {
     HyperLogLog hll3 = HyperLogLog.builder().setEncoding(EncodingType.SPARSE).build();
     HyperLogLog hll4 = HyperLogLog.builder().setNumRegisterIndexBits(16)
         .setEncoding(EncodingType.SPARSE).build();
+    HyperLogLog hll5 = HyperLogLog.builder().setNumRegisterIndexBits(12)
+        .setEncoding(EncodingType.SPARSE).build();
     int size = 500;
     for (int i = 0; i < size; i++) {
       hll.addLong(i);
       hll2.addLong(size + i);
       hll3.addLong(2 * size + i);
+      hll4.addLong(3 * size + i);
     }
     double threshold = size > 40000 ? longRangeTolerance : shortRangeTolerance;
     double delta = threshold * size / 100;
+    double delta4 = threshold * (4*size) / 100;
     assertEquals((double) size, (double) hll.count(), delta);
     assertEquals((double) size, (double) hll2.count(), delta);
 
@@ -96,8 +109,13 @@ public class TestHyperLogLog {
     assertEquals((double) 3 * size, (double) hll.count(), delta);
     assertEquals(EncodingType.SPARSE, hll.getEncoding());
 
-    // invalid merge -- register set size doesn't match
+    // valid merge -- register set size gets bigger & dense automatically
     hll.merge(hll4);
+    assertEquals((double) 4 * size, (double) hll.count(), delta4);
+    assertEquals(EncodingType.DENSE, hll.getEncoding());
+    
+    // invalid merge -- smaller register merge to bigger
+    hll.merge(hll5);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -107,11 +125,14 @@ public class TestHyperLogLog {
     HyperLogLog hll3 = HyperLogLog.builder().setEncoding(EncodingType.DENSE).build();
     HyperLogLog hll4 = HyperLogLog.builder().setNumRegisterIndexBits(16)
         .setEncoding(EncodingType.DENSE).build();
+    HyperLogLog hll5 = HyperLogLog.builder().setNumRegisterIndexBits(12)
+        .setEncoding(EncodingType.DENSE).build();
     int size = 1000;
     for (int i = 0; i < size; i++) {
       hll.addLong(i);
       hll2.addLong(size + i);
       hll3.addLong(2 * size + i);
+      hll4.addLong(3 * size + i);
     }
     double threshold = size > 40000 ? longRangeTolerance : shortRangeTolerance;
     double delta = threshold * size / 100;
@@ -133,8 +154,13 @@ public class TestHyperLogLog {
     assertEquals((double) 3 * size, (double) hll.count(), delta);
     assertEquals(EncodingType.DENSE, hll.getEncoding());
 
-    // invalid merge -- register set size doesn't match
-    hll.merge(hll4);
+    // merge should convert hll2 to DENSE
+    hll2.merge(hll4);
+    assertEquals((double) 2 * size, (double) hll2.count(), delta);
+    assertEquals(EncodingType.DENSE, hll2.getEncoding());
+
+    // invalid merge -- smaller register merge to bigger
+    hll.merge(hll5);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -144,11 +170,14 @@ public class TestHyperLogLog {
     HyperLogLog hll3 = HyperLogLog.builder().setEncoding(EncodingType.SPARSE).build();
     HyperLogLog hll4 = HyperLogLog.builder().setNumRegisterIndexBits(16)
         .setEncoding(EncodingType.SPARSE).build();
+    HyperLogLog hll5 = HyperLogLog.builder().setNumRegisterIndexBits(12)
+        .setEncoding(EncodingType.SPARSE).build();
     int size = 1000;
     for (int i = 0; i < size; i++) {
       hll.addLong(i);
       hll2.addLong(size + i);
       hll3.addLong(2 * size + i);
+      hll4.addLong(3 * size + i);
     }
     double threshold = size > 40000 ? longRangeTolerance : shortRangeTolerance;
     double delta = threshold * size / 100;
@@ -170,8 +199,14 @@ public class TestHyperLogLog {
     assertEquals((double) 3 * size, (double) hll.count(), delta);
     assertEquals(EncodingType.DENSE, hll.getEncoding());
 
-    // invalid merge -- register set size doesn't match
-    hll.merge(hll4);
+    // merge should convert hll3 to DENSE
+    hll3.merge(hll4);
+    assertEquals((double) 2 * size, (double) hll3.count(), delta);
+    assertEquals(EncodingType.DENSE, hll2.getEncoding());
+
+    // invalid merge -- smaller register merge to bigger
+    hll.merge(hll5);
+
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -181,11 +216,14 @@ public class TestHyperLogLog {
     HyperLogLog hll3 = HyperLogLog.builder().setEncoding(EncodingType.SPARSE).build();
     HyperLogLog hll4 = HyperLogLog.builder().setNumRegisterIndexBits(16)
         .setEncoding(EncodingType.SPARSE).build();
+    HyperLogLog hll5 = HyperLogLog.builder().setNumRegisterIndexBits(12)
+        .setEncoding(EncodingType.SPARSE).build();
     int size = 1000;
     for (int i = 0; i < size; i++) {
       hll.addLong(i);
       hll2.addLong(size + i);
       hll3.addLong(2 * size + i);
+      hll4.addLong(3 * size + i);
     }
     double threshold = size > 40000 ? longRangeTolerance : shortRangeTolerance;
     double delta = threshold * size / 100;
@@ -207,8 +245,13 @@ public class TestHyperLogLog {
     assertEquals((double) 3 * size, (double) hll.count(), delta);
     assertEquals(EncodingType.DENSE, hll.getEncoding());
 
-    // invalid merge -- register set size doesn't match
-    hll.merge(hll4);
+    // merge should convert hll2 to DENSE
+    hll2.merge(hll4);
+    assertEquals((double) 2 * size, (double) hll2.count(), delta);
+    assertEquals(EncodingType.DENSE, hll2.getEncoding());
+
+    // invalid merge -- smaller register merge to bigger
+    hll.merge(hll5);
   }
 
   @Test


### PR DESCRIPTION
Allow squashing larger HyperLogLog sets into smaller structures for merging