### PR TITLE
reading data from standard in

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ usage: HyperLogLog
  -p,--num-register-bits <arg>   number of bits from hashcode used as
                                 register index between 4 and 16 (both
                                 inclusive). default = 14
+ -r,--relative-error            print relative error calculation
  -s,--serialize                 serialize hyperloglog to file. specify -o
-                                for output file
+                                for output file                                
+ -t,--standard-in               read data from standard in
+  
 ```
 
 Examples
@@ -55,7 +58,7 @@ Examples
 Test with 'n' random numbers
 
 ```
-#./hll -n 20000
+#./hll -r -n 20000
 Actual count: 20000
 Encoding: DENSE, p: 14, estimatedCardinality: 19993
 Relative error: 0.034999847%
@@ -63,7 +66,7 @@ Relative error: 0.034999847%
 
 Test with input file
 ```
-#./hll -f /etc/passwd
+#./hll -r -f /etc/passwd
 Actual count: 84
 Encoding: SPARSE, p: 14, estimatedCardinality: 84
 Relative error: 0.0%
@@ -71,7 +74,7 @@ Relative error: 0.0%
 
 Test serialization
 ```
-#./hll -n 100000000 -s -o /tmp/out.hll
+#./hll -r -n 100000000 -s -o /tmp/out.hll
 Actual count: 100000000
 Encoding: DENSE, p: 14, estimatedCardinality: 100069607
 Relative error: -0.069606304%
@@ -79,7 +82,7 @@ Serialized hyperloglog to /tmp/out.hll
 Serialized size: 10248 bytes
 Serialization time: 20 ms
 
-./hll -f /etc/passwd -s -o /tmp/out.hll
+./hll -r -f /etc/passwd -s -o /tmp/out.hll
 Actual count: 84
 Encoding: SPARSE, p: 14, estimatedCardinality: 84
 Relative error: 0.0%
@@ -98,7 +101,7 @@ Deserialization time: 42 ms
 
 Test disabling bit-packing of registers
 ```
-#./hll -n 10000000 -b false -s -o /tmp/out.hll
+#./hll -r -n 10000000 -b false -s -o /tmp/out.hll
 Actual count: 10000000
 Encoding: DENSE, p: 14, estimatedCardinality: 10052011
 Relative error: -0.52011013%
@@ -106,6 +109,15 @@ Serialized hyperloglog to /tmp/out.hll
 Serialized size: 16392 bytes
 Serialization time: 27 ms
 ```
+
+Test reading from standard in
+```
+#cat /etc/passwd | ./hll -r -t
+Actual count: 84
+Encoding: SPARSE, p: 14, estimatedCardinality: 84
+Relative error: 0.0%
+```
+
 Issues
 ------
 Bug fixes or improvements are welcome! Please fork the project and send pull request on github. Or report issues here https://github.com/prasanthj/hyperloglog/issues


### PR DESCRIPTION
I've added a reading data from <standard in> functionality and a new option to enable relative error calculation and reduce hashset overhead if no relative error needed.  